### PR TITLE
Adding a module for updating the base image

### DIFF
--- a/content/modules/ROOT/nav.adoc
+++ b/content/modules/ROOT/nav.adoc
@@ -26,14 +26,17 @@
 ** xref:module-05.adoc#update2-vm[Updating the virtual machine]
 ** xref:module-05.adoc#testing[Testing the changes]
 
-* xref:module-06.adoc[6. Repurposing a bootc host]
-** xref:module-06.adoc#write-containerfiles[Write containerfile]
-** xref:module-06.adoc#build[Build and push new image]
-** xref:module-06.adoc#switch-run[Switch the image and run]
-** xref:module-06.adoc##layers[Troubleshooting updates]
+* xref:module-06.adoc[6. Applying RHEL updates to the bootc base images]
+** xref:module-06.adoc#naming[Image naming]
+** xref:module-06.adoc#tag-build[Build with specific image]
+** xref:module-06.adoc#test[Testing locally]
+** xref:module-06.adoc#tag-update[Updates using tags]
 
-* xref:module-07.adoc[7. Local image mode testing]
-** xref:module-07.adoc#test[Testing as a container]
+* xref:module-07.adoc[7. Repurposing a bootc host]
+** xref:module-07.adoc#write-containerfiles[Write containerfile]
+** xref:module-07.adoc#build[Build and push new image]
+** xref:module-07.adoc#switch-run[Switch the image and run]
+** xref:module-07.adoc##layers[Troubleshooting updates]
 
 * xref:module-08.adoc[8. Embedding credentials in an image]
 ** xref:module-08.adoc#add-creds[Embedding emergency credentials]
@@ -41,7 +44,7 @@
 ** xref:module-08.adoc#switch-creds[Changing the virtual machine image]
 ** xref:module-08.adoc#user-test[Test the changes]
 
-* xref:module-09.adoc[9. Deploying a bootc virtual machine with Anaconda]
+* xref:module-09.adoc[9. Deploying a virtual machine with Anaconda]
 ** xref:module-09.adoc#build[Building the installer iso]
 ** xref:module-09.adoc#run[Starting the installation]
 ** xref:module-09.adoc#test[Testing]

--- a/content/modules/ROOT/pages/module-06.adoc
+++ b/content/modules/ROOT/pages/module-06.adoc
@@ -1,208 +1,91 @@
-= Repurposing a bootc host
+= Applying RHEL updates to the bootc base images
 
-In addition to simplifying updates and providing native rollback, operating RHEL in image mode also 
-makes it simple to quickly change the purpose of a running system. This means experimenting with new 
-versions of application components or testing OS updates is as simple as applying any other image change.
+We looked at how to add new software packages to a bootc host, but what about applying updates to packages in the base image? Using `dnf update` during a container build is not a good practice, and can lead to inconsistent images based on package visibility at build time.
 
-In this lab we'll explore this feature as well as expand on the ideas of layering common in the application 
-container world.
+Red Hat publishes updated base images to the Container Catalog regularly, to understand how to make the best use of them, we need to revisit tagging.
 
-[#write-containerfiles]
-== Writing advanced containerfiles
+* Insert a screenshot of the dropdown in the catalog
 
-NOTE: All of the files for this exercise are provided in the examples folder and we'll be operating on those 
-directly. If a command doesn't operate, or a file doesn't look correct, check to make sure you are in the right 
-directory.
+== Anatomy of a container repository
 
-Instead of just running a webserver, what if we needed to run WordPress instances, and our developers need
-those to be containerized? Image mode hosts are suitable for a wide range of use cases beyond directly hosting 
-applications, and acting as a container host is one of those. In fact, the work that preceded image mode was 
-largely focused on the role of container hosting. 
+Remember the naming convention for images is <registry>/<repository>/<name>:<tag>, so for the bootc images we have been using the registry is `registry.redhat.io` and the repository is `rhel9`. The table below describes the tags associated with the `rhel-bootc` image.
+[cols="~,~"]
+|===
+|latest
+|the most recent build of a major release
 
-On the host system (make sure the prompt shows `[lab-user@hypervisor rh-summit-2024-lb1506]$`), you can
-change to the `wordpress-quadlet` directory to examine the new Containerfile.
+|9.5
+|the most recent build of a minor release
 
-[source,bash]
-----
-cd examples/wordpress-quadlet
-cat Containerfile.wp
-----
-Using container tooling to create images let's us take advantage of layers and inheritance in our standard 
-build process. Different teams and work directly from images built by others, rather than by integrating after 
-the fact. Notice our `FROM` line is the image you've been working on throughout the lab. This means that every 
-bit of customization and software you've installed previously will be available on the host built from this new 
-definition. 
+|9.5-1742979700
+|a timestamped build of a minor release
+|===
 
-[source,dockerfile]
-----
-FROM summit.registry/lb1506:bootc
+So far, we have be using `registry.redhat.io/rhel9/rhel-bootc:9.5` in the FROM line of the Containerfile, meaning we are using the most recent build of the 9.5 minor release of the `rhel-bootc` image. 
 
-RUN dnf -y install lynx
+At the time of writing that is also what `latest` would point to. Both of these also point to `9.5-1742979700`, as seen in the screenshot above.
 
-ADD etc/ /etc
-ADD usr/ /usr
-----
+Those timestamps are in UNIX epoch time so the `date` command can show us when a build was made.
 
-For an 'advanced` configuration, this doesn't have a lot of content, what's happening?
-
-Remember the `ADD` directive pulls full directories into the image at build time. So all of the work here is 
-somehow being done in `/usr` or `/etc`, let's see what's in there.
-
-
-[source,bash]
-----
-ls -lahR etc/ usr/
-----
-
-The advanced part is the use of quadlets to run containers. A full description of quadlets is outside the scope 
-of this workshop, but in short, a quadlet is a way to run a container (or group of containers in this case) as a 
-systemd service. In `wordpress-quadlet/etc/` we have a configuration file for the caddy server, a Golang HTTPS server acting as a proxy, 
-and a file of environment variables to be passed to the quadlet.
-
-In `wordpress-quadlet/usr/share/containers/systemd/` we have all of the files that define the quadlet. The `.container` file defines 
-each of the containers for systemd to run. These are typical systemd unit files, aside from the `[Container]` block which 
-is unique to quadlets.
-
-Feel free to explore these files and directories before moving on.
-
-[#build]
-== Build and push the image
-
-When we build this image, we will use a new tag. You may have noticed in the previous exercises, the name of the image has stayed the same. 
-Tags are how `bootc` keeps track of images, which is why each of the previous changes we made showed up as updates. 
-
-
-In this exercise, we're going to look at a different way to change what operating system in installed on a host, so this image will get a new tag. 
-Tagging is a powerful but somewhat subjective way to both provide information about an image and to control what's visible to any particular image 
-mode host. Most of that discussion is out of scope for this lab, but we'll explore how to use an alternate image here. 
-Remember the format for the `--tag` flag is `<registry>/<repository>:<tag>`.
-
-[source,bash]
-----
-podman build --file Containerfile.wp --tag summit.registry/lb1506:bootc-wp
-----
-
-And of course push it to the local registry:
-
-[source,bash]
-----
-podman push summit.registry/lb1506:bootc-wp
-----
-
-Notice that even though we used a new tag for this image, the push still used cached layers. This is an advantage of stacking images in a standard 
-build design.
-
-You can now login to the virtual machine:
-
-[source,bash]
-----
-ssh lab-user@qcow-vm
-----
-
-[#switch-run]
-== Switch and test the image
-
-After the new container image has been pushed to the local registry, you can `switch` the bootc image to the WordPress one. This 
-`bootc` command is how we change what image to follow for updates. From here on, any changes made to the orginal `bootc` tagged image 
-would not show up as an available update, only changes to the new `bootc-wp` image.
-
-[source,bash]
-----
-sudo bootc switch summit.registry/lb1506:bootc-wp
-----
-
-As usual, after the command is done you need to reboot the virtual machine
-for the changes to take effect. Before doing that, please make sure you are logged in to the
-virtual machine and not the hypervisor (the prompt should look like `[lab-user@qcow-vm ~]#`):
-
-[source,bash]
-----
-sudo systemctl reboot
-----
-
-After a short while, you can log back in to the virtual machine:
-
-[source,bash]
-----
-ssh lab-user@qcow-vm
-----
-
-[#layers]
-== Troubleshooting layered builds
-
-Check on the status of our newly created quadlet by checking the caddy proxy server. 
-
-[source,bash]
-----
-sudo systemctl status caddy.service
-sudo journalctl -t caddy
-----
 ....
-Jul 24 14:40:30 qcow-vm systemd[1]: caddy.service: Failed with result 'exit-code'.
-Jul 24 14:40:30 qcow-vm systemd[1]: Failed to start Caddy Quadlet.
-
-Jul 24 14:40:25 qcow-vm caddy[1347]: Error: cannot listen on the TCP port: listen tcp4 :80: 
-Jul 24 14:40:27 qcow-vm caddy[1780]: Error: cannot listen on the TCP port: listen tcp4 :80:
+date -d@1742979700
+Wed Mar 26 05:01:40 AM EDT 2025
 ....
+This also means that should a new build be published to the catalog, that new base image could be used depending on the state of the container image storage cache on the build host.
 
-We weren't prompted for our sudo password, but it looks like our new caddy server couldn't bind to port 80 
-when it tried to start.  What's going on? The answer to both lies in the image we built from. 
+== Updating the base image using timestamps
+Let's build a new image using an older code that still checks out to start.
 
-If we check the status of Apache, we can see that it is indeed running and listening on port 80.
-
-[source,bash]
+[source,dockerfile,role="execute",subs=attributes+]
 ----
-sudo systemctl status httpd.service
-----
+FROM registry.redhat.io/rhel9/rhel-bootc:9.5-1739946498
 
-If you look at the original Containerfile, you'll recall we set Apache to start at boot:
+RUN dnf install -y httpd
+RUN echo "Hello Red Hat" > /var/www/html/index.html
 
-[source,dockerfile]
-----
 RUN systemctl enable httpd.service
 ----
 
-Since local changes to /etc are kept by `bootc` when changing images, httpd stayed enabled on 
-this new host as well. Let's disable it and restart caddy.
+Since we're using a tag that doesn't change in the registry, we know that we will always use the same base image no matter the state of the build host.
 
-[source,bash]
+[source,bash,role="execute",subs=attributes+]
 ----
-sudo systemctl disable --now httpd.service
-sudo systemctl restart caddy.service
-sudo systemctl status caddy.service
-----
-....
-Removed "/etc/systemd/system/multi-user.target.wants/httpd.service".
-
-● caddy.service - Caddy Quadlet
-     Loaded: loaded (/usr/share/containers/systemd/caddy.container; generated)
-     Active: active (running) since Wed 2024-07-24 14:42:21 UTC; 6s ago
-....
-
-It looks like caddy started, let's check to see that it's passing requests to the WordPress 
-container in the quadlet. Curl will dump a mess of HTML and we don't have a GUI, but that's why we installed the Lynx browser
-
-[source,bash]
-----
-lynx localhost
+podman build --file Containerfile --tag {registry_hostname}/httpd
 ----
 
-You should see the WordPress configuration dialog box. You can hit `Q` (Shift + q) to quit lynx.
 
-Feel free to explore the virtual machine before moving on to the next section.
-
-Before proceeding, make sure you have logged out of the virtual machine:
-
-[source,bash]
+[source,bash,role="execute",subs=attributes+]
 ----
-logout
+podman push {registry_hostname}/httpd
 ----
 
-Easy updates, rollbacks, and image switching are part of the core improvements to the operation of 
-image mode systems. Layering is an important part of the design of standard builds and can have some 
-downstream effects as well. Just like stacking configuration management, thinking through the idea of 
-layered builds can be powerful.
+bootc switch on target VM
 
-But those aren't the only advantages or design considerations when thinking about 
-how to best use image mode in your workflows. Let's explore a few more advanced topics next.
+check some version of known RPm update
 
+build with newer timestamp
+
+[source,dockerfile,role="execute",subs=attributes+]
+----
+FROM registry.redhat.io/rhel9/rhel-bootc:9.5-1742979700
+
+RUN dnf install -y httpd
+RUN echo "Hello Red Hat" > /var/www/html/index.html
+
+RUN systemctl enable httpd.service
+----
+
+Since we're using a tag that doesn't change in the registry, we know that we will always use the same base image no matter the state of the build host.
+
+[source,bash,role="execute",subs=attributes+]
+----
+podman build --file Containerfile --tag {registry_hostname}/httpd
+----
+ Note we're using the same naming and tag for the image with our application in it. We want the host to see this as an update, not as a new image to switch into.
+
+[source,bash,role="execute",subs=attributes+]
+----
+podman push {registry_hostname}/httpd
+----
+
+Making use of the tags in the catalog provides you with more options to control and trace your images. And to do the same with the packages you install, you can use something like Satellite to control the visibility of new packages at build time.

--- a/content/modules/ROOT/pages/module-06.adoc
+++ b/content/modules/ROOT/pages/module-06.adoc
@@ -6,35 +6,76 @@ Red Hat publishes updated base images to the Container Catalog regularly, to und
 
 * Insert a screenshot of the dropdown in the catalog
 
-== Anatomy of a container repository
+[#naming]
+== What's in a name?
 
-Remember the naming convention for images is <registry>/<repository>/<name>:<tag>, so for the bootc images we have been using the registry is `registry.redhat.io` and the repository is `rhel9`. The table below describes the tags associated with the `rhel-bootc` image.
+Let's do a quick refresher on what makes up the 'name' of a container image. The official convention for images is <host>/<namespace>/<repository>:<tag>.
+[cols="~,~"]
+|===
+|host
+|domain name of the registry in use, can include a port number if needed (eg `localhost:5000`)
+
+|namespace
+|(optional) usually the username or organization name within the registry, can represent other things depending on the registry service. _Not to be confused with Linux namespaces within the kernel._ (eg `quay.io/prometheus`)
+
+|repository
+|what most folks think of as the 'name' of an image, but technically a space for a collection of images, typically related. these days, this collection is typically just iterations of a single image over time, not totally different but related images (eg `rhel-bootc`) 
+
+|tag
+|(optional) identifier for a specific image in the repository, used to convey some information about the contents of the image, has a default of `latest` (eg `rhel-bootc:9.5`)
+
+|digest
+|not part of the naming, but how images and tags in registries are actually tracked via SHA256, can be used to pull specific images directly (eg `rhel-bootc@sha256:ee593d553dcda33f424bc0d262fef35b207e0a7df1dce3a0e25584b139c4a4ef`)
+|===
+
+So far, we have be using `registry.redhat.io/rhel9/rhel-bootc:9.5` in the FROM line of the Containerfile, so let's break that down according to our table:
+
+[cols="~,~"]
+|===
+|host
+|registry.redhat.io
+
+|namespace
+|rhel9
+
+|repository
+|rhel-bootc
+
+|tag
+|9.5
+|===
+
+The earlier RHEL 9.4 images are also in the same `rhel-bootc` repository of the `rhel9` namespace. This lets us keep the base images organized in a few different ways by using tags.
+
+The table below describes the tags associated with the `rhel-bootc` repository.
 [cols="~,~"]
 |===
 |latest
-|the most recent build of a major release
+|the most recent minor release build *within a major* release
 
 |9.5
-|the most recent build of a minor release
+|the most recent build of a *particular minor* release
 
 |9.5-1742979700
-|a timestamped build of a minor release
+|a *timestamped build* of a minor release
 |===
 
-So far, we have be using `registry.redhat.io/rhel9/rhel-bootc:9.5` in the FROM line of the Containerfile, meaning we are using the most recent build of the 9.5 minor release of the `rhel-bootc` image. 
-
-At the time of writing that is also what `latest` would point to. Both of these also point to `9.5-1742979700`, as seen in the screenshot above.
-
-Those timestamps are in UNIX epoch time so the `date` command can show us when a build was made.
-
+[TIP]
+====
+Those timestamps are in UNIX epoch time, so the `date` command can show us when a build was made.
 ....
 date -d@1742979700
 Wed Mar 26 05:01:40 AM EDT 2025
 ....
-This also means that should a new build be published to the catalog, that new base image could be used depending on the state of the container image storage cache on the build host.
+====
 
-== Updating the base image using timestamps
-Let's build a new image using an older code that still checks out to start.
+At the time of writing, `latest` would point to `9.5`, the most current minor release of RHEL 9. Both of these also point to `9.5-1742979700`, as seen in the screenshot above. This also means that should a new timestamped build be published to the catalog, the `9.5` tag would automatically update to that next new build. 
+
+If that new build were a new minor release (eg 9.6), the `latest` tag would point to that minor. Knowing what tags point to what images, and therefor what software is available in your base image is important. 
+
+[#tag-build]
+== Using specific versions of base images
+Let's build a new image using an older tag that still checks out to get an idea of how this works and how you can use it to control updates.
 
 [source,dockerfile,role="execute",subs=attributes+]
 ----
@@ -45,26 +86,59 @@ RUN echo "Hello Red Hat" > /var/www/html/index.html
 
 RUN systemctl enable httpd.service
 ----
-
-Since we're using a tag that doesn't change in the registry, we know that we will always use the same base image no matter the state of the build host.
-
-[source,bash,role="execute",subs=attributes+]
-----
-podman build --file Containerfile --tag {registry_hostname}/httpd
-----
-
+[NOTE]
+====
+Since we're using a tag that doesn't change in the registry, we know that we will always use the same base image no matter the state of the build host. If we had fewer tags or ones that moved more frequently, this is where we could use the SHA256 digest instead of a tag to be specific about image use.
+====
 
 [source,bash,role="execute",subs=attributes+]
 ----
-podman push {registry_hostname}/httpd
+podman build --file Containerfile --tag {registry_hostname}/base-check
 ----
+You should notice that this build starts by pulling the base image, since it's different than what we have been using.  Since this is just an older version, you will still see shared layers being skipped.
 
-bootc switch on target VM
+[#test]
+== Locally testing builds
+In our normal workflow, we'd push this image to the registry and then update a bootc host to see any changes. Since these are, after all, container images, we can inspect them locally. Being able to run certain kinds of tests using a container engine without needing to fully boot an image can be a useful tool, especially when iterating on a build.
 
-check some version of known RPm update
+Let's check the version of the kernel that was shipped in this older base image by running a shell in a temporary container.
 
-build with newer timestamp
+[source,bash,role="execute",subs=attributes+]
+----
+podman run --rm -i {registry_hostname}/base-check rpm -qa httpd kernel*
+----
+The arguments we pass to `podman run` are:
 
+  * `--rm` -> remove the container immediately on exit
+  * `-i` -> pipe stdin into the container
+  * `{registry_hostname}/base-check` -> the image we just built to launch the container
+  * `rpm -qa httpd kernel*` -> the command to read from stdin and run inside the temporary container
+....
+kernel-modules-core-5.14.0-503.23.2.el9_5.x86_64
+kernel-core-5.14.0-503.23.2.el9_5.x86_64
+kernel-modules-5.14.0-503.23.2.el9_5.x86_64
+kernel-5.14.0-503.23.2.el9_5.x86_64
+httpd-2.4.62-1.el9_5.2.x86_64
+....
+
+You may be tempted to check the kernel version with something like `uname -r`, let's see what happens
+[source,bash,role="execute",subs=attributes+]
+----
+podman run --rm -i {registry_hostname}/base-check uname -r
+----
+....
+5.14.0-503.31.1.el9_5.x86_64
+....
+
+Since this is a container, and not a VM, we will see the host's system kernel version not the one from the RPM list.
+
+This sort of local testing is often called the 'inner loop' in software development, something not previously available to the design and development of standard operating system builds. For some testing, you need to launch a container fully to get `systemd` started instead of running it interactively, like checking on the httpd service.
+
+While not every nuance of system behavior can be tested in a container (eg SELinux polices), this still can greatly reduce the amount of time usually needed to test changes Local VMs, like used in this lab, can be a very good way to create a full local testing environment for new bootc images. 
+
+[#tag-update]
+== Updating the base image using tags
+To update the base image, we only need to change the tag to the latest timestamp variant (as of the writing of this exercise) and build the image:
 [source,dockerfile,role="execute",subs=attributes+]
 ----
 FROM registry.redhat.io/rhel9/rhel-bootc:9.5-1742979700
@@ -75,17 +149,31 @@ RUN echo "Hello Red Hat" > /var/www/html/index.html
 RUN systemctl enable httpd.service
 ----
 
-Since we're using a tag that doesn't change in the registry, we know that we will always use the same base image no matter the state of the build host.
-
 [source,bash,role="execute",subs=attributes+]
 ----
-podman build --file Containerfile --tag {registry_hostname}/httpd
+podman build --file Containerfile --tag {registry_hostname}/base-check
 ----
- Note we're using the same naming and tag for the image with our application in it. We want the host to see this as an update, not as a new image to switch into.
+You should notice that this build skips *all* of the layers when pulling the base image. While it's a different tag, it's the same image as the one we've used throughout the exercises. Multiple tags can refer to a single image, allow you to convey meaningful information about an image. 
 
+You should also notice that we completely rebuilt the image, since the change in the container definition was at the very first instruction. This means the whole cache is skipped, unlike the previous builds in this lab.
+
+Now let's check the package versions in this base image using the same commands as before, but with our new image.
 [source,bash,role="execute",subs=attributes+]
 ----
-podman push {registry_hostname}/httpd
+podman run --rm -i {registry_hostname}/base-check rpm -qa httpd kernel*
 ----
+....
+kernel-modules-core-5.14.0-503.33.1.el9_5.x86_64
+kernel-core-5.14.0-503.33.1.el9_5.x86_64
+kernel-modules-5.14.0-503.33.1.el9_5.x86_64
+kernel-5.14.0-503.33.1.el9_5.x86_64
+httpd-2.4.62-1.el9_5.2.x86_64
+....
 
-Making use of the tags in the catalog provides you with more options to control and trace your images. And to do the same with the packages you install, you can use something like Satellite to control the visibility of new packages at build time.
+There's a newer kernel provided by the updated base image, but the version of httpd installed is the same. We're using repositories directly from the Red Hat services, any packages we add during the container build will be whatever is most recently published. You can also update to a newer minor version by simply changing the tag to match.
+
+// ANCHOR NEW BRANCH HERE
+
+Making use of the tags in the catalog provides you with more options to control and trace your base images. To do the same with the packages you install on top of the base, you can use something like Satellite to control the visibility of new packages at build time. This combination can eliminate any drift between base images and installed packages from repositories.
+
+You could routinely check the catalog for updates on some set schedule that works for your operational needs. This could be tedious across a large number of standard builds and could be automated. You could also take advantage of a new set of tools, not usually available for standard operating environment build and design. As image mode uses standard container methods, you can use other standard container tools like those that drive current gitops pipelines. This opens the door to entirely different ways of automating the building, deploying, and maintaining of your standard operating environments and the application images that use them. If you'd like to read more about a gitops flow, we have a blog that https://www.redhat.com/en/blog/jumpstart-gitops-image-mode[walks through a simple set up on GitHub] with an accompanying template.

--- a/content/modules/ROOT/pages/module-07.adoc
+++ b/content/modules/ROOT/pages/module-07.adoc
@@ -1,101 +1,208 @@
-= Creating an inner loop for system design
-In this exercise, you'll look at how to test without needing to deploy the image to a host.
+= Repurposing a bootc host
 
-NOTE: You should on the lab host (the prompt should look like `[lab-user@hypervisor rh-summit-2024-lb1506]$``), if not log out of the VM now.
+In addition to simplifying updates and providing native rollback, operating RHEL in image mode also 
+makes it simple to quickly change the purpose of a running system. This means experimenting with new 
+versions of application components or testing OS updates is as simple as applying any other image change.
 
+In this lab we'll explore this feature as well as expand on the ideas of layering common in the application 
+container world.
 
-Being able to make changes, build, and run an application locally is part of what is called
-the 'inner loop' of application development. Containers had a big impact on making local 
-development and production run time look and feel identical, improving the inner loop for developers. 
-One advantages of image mode, the use of standard container tools brings this 'inner loop' capability 
-to the design and development of standard operating system builds. 
+[#write-containerfiles]
+== Writing advanced containerfiles
 
-While not every nuance of system behavior can be tested this way (eg SELinux polices), this still 
-can greatly reduce the amount of time usually needed to test changes to configurations, software installations, etc.
+NOTE: All of the files for this exercise are provided in the examples folder and we'll be operating on those 
+directly. If a command doesn't operate, or a file doesn't look correct, check to make sure you are in the right 
+directory.
 
-[#test]
-== Testing a bootc image as a container
+Instead of just running a webserver, what if we needed to run WordPress instances, and our developers need
+those to be containerized? Image mode hosts are suitable for a wide range of use cases beyond directly hosting 
+applications, and acting as a container host is one of those. In fact, the work that preceded image mode was 
+largely focused on the role of container hosting. 
 
-You can launch this bootc container like any other application container, `podman` will
-start `systemd` by default. Using `--detach` will help ensure that `systemd` is PID1 and 
-the bootc image will initialize as intended when running as a host.
-
-[source,bash]
-----
-podman run --rm --name http-test --detach --publish 80:80 summit.registry/lb1506:bootc
-----
-
-Test that it is running:
+On the host system (make sure the prompt shows `[lab-user@hypervisor rh-summit-2024-lb1506]$`), you can
+change to the `wordpress-quadlet` directory to examine the new Containerfile.
 
 [source,bash]
 ----
-podman ps | grep http-test
+cd examples/wordpress-quadlet
+cat Containerfile.wp
+----
+Using container tooling to create images let's us take advantage of layers and inheritance in our standard 
+build process. Different teams and work directly from images built by others, rather than by integrating after 
+the fact. Notice our `FROM` line is the image you've been working on throughout the lab. This means that every 
+bit of customization and software you've installed previously will be available on the host built from this new 
+definition. 
+
+[source,dockerfile]
+----
+FROM summit.registry/lb1506:bootc
+
+RUN dnf -y install lynx
+
+ADD etc/ /etc
+ADD usr/ /usr
 ----
 
-The output of the command above should resemble:
+For an 'advanced` configuration, this doesn't have a lot of content, what's happening?
 
-----
-06a7bdb1950b  summit.registry/lb1506:latest    15 seconds ago  Up 16 seconds  0.0.0.0:80->80/tcp    http-test
-----
+Remember the `ADD` directive pulls full directories into the image at build time. So all of the work here is 
+somehow being done in `/usr` or `/etc`, let's see what's in there.
 
-We exposed a port from the container on the lab host, so we can test the web server.
 
 [source,bash]
 ----
-curl http://localhost/
+ls -lahR etc/ usr/
 ----
 
-The result of the command above should be the latest index.html we created.
+The advanced part is the use of quadlets to run containers. A full description of quadlets is outside the scope 
+of this workshop, but in short, a quadlet is a way to run a container (or group of containers in this case) as a 
+systemd service. In `wordpress-quadlet/etc/` we have a configuration file for the caddy server, a Golang HTTPS server acting as a proxy, 
+and a file of environment variables to be passed to the quadlet.
 
-----
-Hello Red Hat Summit Connect 2024!!
-----
+In `wordpress-quadlet/usr/share/containers/systemd/` we have all of the files that define the quadlet. The `.container` file defines 
+each of the containers for systemd to run. These are typical systemd unit files, aside from the `[Container]` block which 
+is unique to quadlets.
 
-Before we attach to an interactive shell in the running container, let's get the kernel command line from the 
-lab host.
+Feel free to explore these files and directories before moving on.
+
+[#build]
+== Build and push the image
+
+When we build this image, we will use a new tag. You may have noticed in the previous exercises, the name of the image has stayed the same. 
+Tags are how `bootc` keeps track of images, which is why each of the previous changes we made showed up as updates. 
+
+
+In this exercise, we're going to look at a different way to change what operating system in installed on a host, so this image will get a new tag. 
+Tagging is a powerful but somewhat subjective way to both provide information about an image and to control what's visible to any particular image 
+mode host. Most of that discussion is out of scope for this lab, but we'll explore how to use an alternate image here. 
+Remember the format for the `--tag` flag is `<registry>/<repository>:<tag>`.
 
 [source,bash]
 ----
-cat /proc/cmdline
+podman build --file Containerfile.wp --tag summit.registry/lb1506:bootc-wp
+----
+
+And of course push it to the local registry:
+
+[source,bash]
+----
+podman push summit.registry/lb1506:bootc-wp
+----
+
+Notice that even though we used a new tag for this image, the push still used cached layers. This is an advantage of stacking images in a standard 
+build design.
+
+You can now login to the virtual machine:
+
+[source,bash]
+----
+ssh lab-user@qcow-vm
+----
+
+[#switch-run]
+== Switch and test the image
+
+After the new container image has been pushed to the local registry, you can `switch` the bootc image to the WordPress one. This 
+`bootc` command is how we change what image to follow for updates. From here on, any changes made to the orginal `bootc` tagged image 
+would not show up as an available update, only changes to the new `bootc-wp` image.
+
+[source,bash]
+----
+sudo bootc switch summit.registry/lb1506:bootc-wp
+----
+
+As usual, after the command is done you need to reboot the virtual machine
+for the changes to take effect. Before doing that, please make sure you are logged in to the
+virtual machine and not the hypervisor (the prompt should look like `[lab-user@qcow-vm ~]#`):
+
+[source,bash]
+----
+sudo systemctl reboot
+----
+
+After a short while, you can log back in to the virtual machine:
+
+[source,bash]
+----
+ssh lab-user@qcow-vm
+----
+
+[#layers]
+== Troubleshooting layered builds
+
+Check on the status of our newly created quadlet by checking the caddy proxy server. 
+
+[source,bash]
+----
+sudo systemctl status caddy.service
+sudo journalctl -t caddy
 ----
 ....
-BOOT_IMAGE=/boot/vmlinuz root=UUID=60d0e5e3-7217-4c34-b8e0-fd3d9abf0654 ro console=tty0 console=ttyS1,115200n8 biosdevname=0 net.naming-scheme=rhel-9.3 net.ifnames=1 modprobe.blacklist=igb modprobe.blacklist=rndis_host
+Jul 24 14:40:30 qcow-vm systemd[1]: caddy.service: Failed with result 'exit-code'.
+Jul 24 14:40:30 qcow-vm systemd[1]: Failed to start Caddy Quadlet.
+
+Jul 24 14:40:25 qcow-vm caddy[1347]: Error: cannot listen on the TCP port: listen tcp4 :80: 
+Jul 24 14:40:27 qcow-vm caddy[1780]: Error: cannot listen on the TCP port: listen tcp4 :80:
 ....
 
-Now we can get our shell in the running container.
-[source,bash]
-----
-podman exec -it  http-test /bin/bash
-----
-....
-bash-5.1# 
-....
+We weren't prompted for our sudo password, but it looks like our new caddy server couldn't bind to port 80 
+when it tried to start.  What's going on? The answer to both lies in the image we built from. 
 
-Let's look at kernel command line as well as PID1 in the `/proc` filesystem and see what runtime info we have.
-
-[source,bash]
-----
-cat /proc/cmdline # <1>
-cat /proc/1/cgroup # <2>
-cat /proc/1/attr/current # <3>
-----
-
-We can see the kernel command line is taken from the lab host since there's no running kernel in a container, systemd is running 
-as the init system from the cgroup hierarchy but a different SELinux context. Remember that systemd is run as PID1 by default 
-when a bootc image is run as a container, but since it wasn't booted as a host, none of the first boot preparation will be executed.
-
-<1> `BOOT_IMAGE=/boot/vmlinuz root=UUID=60d0e5e3-7217-4c34-b8e0-fd3d9abf0654 ro console=tty0 console=ttyS1,115200n8 biosdevname=0 net.naming-scheme=rhel-9.3 net.ifnames=1 modprobe.blacklist=igb modprobe.blacklist=rndis_host`
-<2> `0::/init.scope`
-<3> `system_u:system_r:container_init_t:s0:c472,c516`
-
-You can use this container to experiment with changes, understand dependecies that new software might bring, check that services can be 
-started, and more. While issues we introduced in the switch exercise may not be discovered here, there is still a lot that can be done 
-to speed creation and testing of new operating system builds.
-
-Once you're done testing, go ahead and exit the shell, and stop the running container on the host:
+If we check the status of Apache, we can see that it is indeed running and listening on port 80.
 
 [source,bash]
 ----
-exit
-podman stop http-test
+sudo systemctl status httpd.service
 ----
+
+If you look at the original Containerfile, you'll recall we set Apache to start at boot:
+
+[source,dockerfile]
+----
+RUN systemctl enable httpd.service
+----
+
+Since local changes to /etc are kept by `bootc` when changing images, httpd stayed enabled on 
+this new host as well. Let's disable it and restart caddy.
+
+[source,bash]
+----
+sudo systemctl disable --now httpd.service
+sudo systemctl restart caddy.service
+sudo systemctl status caddy.service
+----
+....
+Removed "/etc/systemd/system/multi-user.target.wants/httpd.service".
+
+● caddy.service - Caddy Quadlet
+     Loaded: loaded (/usr/share/containers/systemd/caddy.container; generated)
+     Active: active (running) since Wed 2024-07-24 14:42:21 UTC; 6s ago
+....
+
+It looks like caddy started, let's check to see that it's passing requests to the WordPress 
+container in the quadlet. Curl will dump a mess of HTML and we don't have a GUI, but that's why we installed the Lynx browser
+
+[source,bash]
+----
+lynx localhost
+----
+
+You should see the WordPress configuration dialog box. You can hit `Q` (Shift + q) to quit lynx.
+
+Feel free to explore the virtual machine before moving on to the next section.
+
+Before proceeding, make sure you have logged out of the virtual machine:
+
+[source,bash]
+----
+logout
+----
+
+Easy updates, rollbacks, and image switching are part of the core improvements to the operation of 
+image mode systems. Layering is an important part of the design of standard builds and can have some 
+downstream effects as well. Just like stacking configuration management, thinking through the idea of 
+layered builds can be powerful.
+
+But those aren't the only advantages or design considerations when thinking about 
+how to best use image mode in your workflows. Let's explore a few more advanced topics next.
+

--- a/content/modules/ROOT/pages/module-08.adoc
+++ b/content/modules/ROOT/pages/module-08.adoc
@@ -1,194 +1,101 @@
-= Exploring alternate user creation methods
+= Creating an inner loop for system design
+In this exercise, you'll look at how to test without needing to deploy the image to a host.
 
-In this exercise, you'll explore other ways to create users and add credentials to image mode hosts.
+NOTE: You should on the lab host (the prompt should look like `[lab-user@hypervisor rh-summit-2024-lb1506]$``), if not log out of the VM now.
 
-[#add-creds]
-== Embedding emergency credentials into an image
-In the previous exercises, we've created users and added ssh keys at install time, either via a blueprint file 
-passed to `bootc-image-builder` or via kickstart to Anaconda. There are many ways and many reasons why handling 
-users would happen at any particular stage of the process, during deployment or after install via network authentication.
 
-In addition to adding users during the creation of a host system, via `bootc-image-builder`, `cloud-init`, or some other means, we can also create users during
-the creation of the bootc image. This can be useful in certain cases where particular emergency users are needed in environments with limited connectivity. 
-These users and credentials would be tied to the image, which means controlling how secrets are used in the build are important to understand before going 
-down this path. You will want to explore more before making this choice in your own environment.
+Being able to make changes, build, and run an application locally is part of what is called
+the 'inner loop' of application development. Containers had a big impact on making local 
+development and production run time look and feel identical, improving the inner loop for developers. 
+One advantages of image mode, the use of standard container tools brings this 'inner loop' capability 
+to the design and development of standard operating system builds. 
 
-On the host system (make sure the prompt shows `[lab-user@hypervisor rh-summit-2024-lb1506]$`), and are in the `rh-summit-2024-lb1506` directory
+While not every nuance of system behavior can be tested this way (eg SELinux polices), this still 
+can greatly reduce the amount of time usually needed to test changes to configurations, software installations, etc.
 
-[source,bash]
-----
-cd ~/rh-summit-2024-lb1506
-----
+[#test]
+== Testing a bootc image as a container
 
-[#secrets]
-== Using podman secrets at build time
-
-We will use an addtional feature of `podman` to get the credentials we want to embed passed to the image safely.
-
-You can now edit the `Containerfile` to match the following:
-
-[source,dockerfile]
-----
-FROM registry.redhat.io/rhel9/rhel-bootc:9.4
-
-COPY certs/004-summit.conf /etc/containers/registries.conf.d/004-summit.conf
-
-COPY templates/30-auth-system.conf /etc/ssh/sshd_config.d/30-auth-system.conf # <1>
-RUN mkdir -p /usr/ssh # <2>
-RUN --mount=type=secret,id=SSHPUBKEY cat /run/secrets/SSHPUBKEY > /usr/ssh/root.keys && chmod 0600 /usr/ssh/root.keys # <3>
-
-ADD etc/ /etc
-
-RUN dnf install -y httpd
-
-RUN <<EOF
-    mv /var/www /usr/share/www
-    sed -i 's-/var/www-/usr/share/www-' /etc/httpd/conf/httpd.conf
-EOF
-
-RUN echo "Hello Red Hat Summit Connect 2024!!" > /usr/share/www/html/index.html
-
-RUN systemctl enable httpd.service
-----
-<1> `COPY templates...` -> adds a drop in for sshd to look for public keys in users global `.keys` file, note this is in `/usr` and tied to the image
-<2> `RUN mkdir -p /usr/ssh` -> create the new keys directory in `/usr`
-<3> `RUN --mount=type=secret,id=SSHPUBKEY cat /run/secrets/SSHPUBKEY .. ` -> mounts the secret passed via build to a file only available at build time, then copies the contents
-
-You can now build the new container image with the following command, note the `--secret` argument. This is the connection to the `RUN` directive 
-in the Containerfile. At build time, `podman` will take the file passed and create a temporary secret which we can mount only during the build process. 
-The `id` of the secret is the filename mounted under `/run/secrets`, which we then can extract the contents for our ssh key.
-
-We're also going to use a new tag for this image, like we did in the previous `bootc switch` exercise.
+You can launch this bootc container like any other application container, `podman` will
+start `systemd` by default. Using `--detach` will help ensure that `systemd` is PID1 and 
+the bootc image will initialize as intended when running as a host.
 
 [source,bash]
 ----
-podman build --secret id=SSHPUBKEY,src=/home/lab-user/.ssh/id_rsa.pub --file Containerfile --tag summit.registry/lb1506:bootc-auth
+podman run --rm --name http-test --detach --publish 80:80 summit.registry/lb1506:bootc
 ----
 
-And make sure to push it to the registry:
+Test that it is running:
 
 [source,bash]
 ----
-podman push summit.registry/lb1506:bootc-auth
+podman ps | grep http-test
 ----
 
-[#switch-creds]
-== Changing the virtual machine image
+The output of the command above should resemble:
 
-The virtual machine you have been working with during this workshop should still be running. You can check this with
+----
+06a7bdb1950b  summit.registry/lb1506:latest    15 seconds ago  Up 16 seconds  0.0.0.0:80->80/tcp    http-test
+----
+
+We exposed a port from the container on the lab host, so we can test the web server.
 
 [source,bash]
 ----
-virsh --connect qemu:///system list
+curl http://localhost/
 ----
 
-And the output should contain a virtual machine called `qcow`.
+The result of the command above should be the latest index.html we created.
 
-Now you can ssh into the virtual machine
+----
+Hello Red Hat Summit Connect 2024!!
+----
+
+Before we attach to an interactive shell in the running container, let's get the kernel command line from the 
+lab host.
 
 [source,bash]
 ----
-ssh lab-user@qcow-vm
+cat /proc/cmdline
 ----
+....
+BOOT_IMAGE=/boot/vmlinuz root=UUID=60d0e5e3-7217-4c34-b8e0-fd3d9abf0654 ro console=tty0 console=ttyS1,115200n8 biosdevname=0 net.naming-scheme=rhel-9.3 net.ifnames=1 modprobe.blacklist=igb modprobe.blacklist=rndis_host
+....
 
-We can change to our new image with the embedded `root` credentials
+Now we can get our shell in the running container.
+[source,bash]
+----
+podman exec -it  http-test /bin/bash
+----
+....
+bash-5.1# 
+....
+
+Let's look at kernel command line as well as PID1 in the `/proc` filesystem and see what runtime info we have.
 
 [source,bash]
 ----
-sudo bootc switch summit.registry/lb1506:bootc-auth
+cat /proc/cmdline # <1>
+cat /proc/1/cgroup # <2>
+cat /proc/1/attr/current # <3>
 ----
 
-The output should look something like this:
+We can see the kernel command line is taken from the lab host since there's no running kernel in a container, systemd is running 
+as the init system from the cgroup hierarchy but a different SELinux context. Remember that systemd is run as PID1 by default 
+when a bootc image is run as a container, but since it wasn't booted as a host, none of the first boot preparation will be executed.
 
-----
-layers already present: 68; layers needed: 7 (126.7 MB)
- 452 B [████████████████████] (0s) Fetched layer sha256:2691e6642975            
-Pruned images: 0 (layers: 0, objsize: 58.9 MB)
-Queued for next boot: summit.registry/lb1506:bootc-auth
-  Version: 9.20240721.0
-  Digest: sha256:2afd495b9dd3e72aa4926deb1e738af54e0b1bb935803bc6c107bdd919347167
-----
-As usual, after the command is done you need to reboot the virtual machine
-for the changes to take effect. Before doing that, please make sure you are logged in to the
-virtual machine and not the hypervisor (the prompt should look like `[lab-user@qcow-vm ~]#`):
+<1> `BOOT_IMAGE=/boot/vmlinuz root=UUID=60d0e5e3-7217-4c34-b8e0-fd3d9abf0654 ro console=tty0 console=ttyS1,115200n8 biosdevname=0 net.naming-scheme=rhel-9.3 net.ifnames=1 modprobe.blacklist=igb modprobe.blacklist=rndis_host`
+<2> `0::/init.scope`
+<3> `system_u:system_r:container_init_t:s0:c472,c516`
+
+You can use this container to experiment with changes, understand dependecies that new software might bring, check that services can be 
+started, and more. While issues we introduced in the switch exercise may not be discovered here, there is still a lot that can be done 
+to speed creation and testing of new operating system builds.
+
+Once you're done testing, go ahead and exit the shell, and stop the running container on the host:
 
 [source,bash]
 ----
-sudo systemctl reboot
-----
-
-[#user-test]
-== Testing the changes
-
-You can now login to the virtual machine with the newly added root credentials:
-
-[source,bash]
-----
-ssh root@qcow-vm
-----
-
-And check once again the status of bootc (no need to use `sudo`, you are root):
-
-[source,bash]
-----
-bootc status
-----
-
-The output should look like this:
-
-[source,yaml]
-----
-apiVersion: org.containers.bootc/v1alpha1
-kind: BootcHost
-metadata:
-  name: host
-spec:
-  image:
-    image: summit.registry/lb1506:bootc-auth
-    transport: registry
-  bootOrder: default
-status:
-  staged: null
-  booted:
-    image:
-      image:
-        image: summit.registry/lb1506:bootc-auth
-        transport: registry
-      version: 9.20240721.0
-      timestamp: null
-      imageDigest: sha256:2afd495b9dd3e72aa4926deb1e738af54e0b1bb935803bc6c107bdd919347167
-    cachedUpdate: null
-    incompatible: false
-    pinned: false
-    ostree:
-      checksum: 6307d9fdc8be3f0c202ce49e311b1d046d6d606dea7bcff51ad5d8910f7887b3
-      deploySerial: 0
-  rollback:
-    image:
-      image:
-        image: summit.registry/lb1506:bootc-wp
-        transport: registry
-      version: 9.20240721.0
-      timestamp: null
-      imageDigest: sha256:af3c6bd4ae7beb9bb10f9846c7bc9d9ba1ede259b4b45e581ddcd97ab2df4380
-    cachedUpdate: null
-    incompatible: false
-    pinned: false
-    ostree:
-      checksum: 543f6c9a5b8e2f354db71adda5db7ca74b53bcb9fdf8c8fcd391e7c66c77062a
-      deploySerial: 0
-  rollbackQueued: false
-  type: bootcHost
-----
-
-Feel free to explore the virtual machine before moving on to the next section, remembering you are now `root`.
-
-Since we've moved away from the WordPress image back to a standard httpd service, you can look for the original 
-index file on disk or via `curl`.
-
-Before proceeding, make sure you have logged out of the virtual machine:
-
-[source,bash]
-----
-logout
+exit
+podman stop http-test
 ----

--- a/content/modules/ROOT/pages/module-09.adoc
+++ b/content/modules/ROOT/pages/module-09.adoc
@@ -1,257 +1,140 @@
-= Creating an install iso with Anaconda
+= Exploring alternate user creation methods
 
-In this section you will learn the basics of deploying a bootc image using Anaconda and an
-all in one `iso` image.
+In this exercise, you'll explore other ways to create users and add credentials to image mode hosts.
 
-Anaconda is the official Red Hat Enterprise Linux installer and it uses Kickstart as it's scripting language.
-Recently, Kickstart received a new command called `ostreecontainer`.
+[#add-creds]
+== Embedding emergency credentials into an image
+In the previous exercises, we've created users and added ssh keys at install time, either via a blueprint file 
+passed to `bootc-image-builder` or via kickstart to Anaconda. There are many ways and many reasons why handling 
+users would happen at any particular stage of the process, during deployment or after install via network authentication.
 
-[#build]
-== Building an installation ISO with the bootc image
+In addition to adding users during the creation of a host system, via `bootc-image-builder`, `cloud-init`, or some other means, we can also create users during
+the creation of the bootc image. This can be useful in certain cases where particular emergency users are needed in environments with limited connectivity. 
+These users and credentials would be tied to the image, which means controlling how secrets are used in the build are important to understand before going 
+down this path. You will want to explore more before making this choice in your own environment.
 
-Anaconda is typically used via the boot iso shipped by Red Hat. There are several ways to get a host to boot from this ISO 
-image including PXE or HTTP Boot over the network, as an image via IMPI, or a physical disk inserted into a drive. The kickstart 
-file for an install can also be provided in several ways, including as part of the iso or over a network. For this section of the lab, 
-we'll focus on creating a boot ISO that includes the kickstart, mainly for local logistics reasons. The configuration of 
-Anaconda via kickstart will be the same, regardless of how they are presented to the host being installed.
-
-To create the ISO with an embedded kickstart, we will use `bootc-image-builder`.
-
-Make sure you have the bootc image to be installed pushed to the local registry:
-
-----
-podman push summit.registry/lb1506:bootc
-----
-
-[#kickstart]
-== Creating the kickstart file
-
-The Kickstart added to the iso via a customization block of the `bootc-image-builder` config file. Add the following to `config-iso.toml` and save the file.
-----
-[customizations.installer.kickstart]
-contents = """
-# Basic setup
-text
-
-network --bootproto=dhcp --device=link --activate 
-
-# Basic partitioning
-clearpart --all --initlabel --disklabel=gpt
-reqpart --add-boot
-part / --grow --fstype xfs
-
-# No ostreecontainer command needed, instead we lay down the container contents with BIB in the ISO
-
-firewall --disabled
-services --enabled=sshd
-
-user --name=core --groups=wheel --iscrypted --password=$PASSHASH
-sshkey --username=core "$SSHKEY"
-
-# Only inject a SSH key for root
-rootpw --iscrypted locked
-
-reboot
-----
-
-All of  the kickstart is standard fare. Anaconda will create the partitions and filesystems on disk, enable services, and create users just like it would in any other install. You even have access to the `%pre` and `%post` blocks too, the only missing section from any kickstart you have today is the `%packages` list. 
-
-The new `ostreecontainer` command replaces the standard %packages block of the kickstart file that defines what RPMs would be installed by Anaconda. This replaces that set of RPM transactions with the `bootc` image to be unpacked and installed to disk.  
-
-  * `--url=/run/install/repo/container` -> path to the local container in the iso but it can also directly take a publicly available registry
-  * `--transport=oci` -> the format in which the container is available, in this case `oci`
-
-If you wanted to deploy directly from a container registry, the `ostreecontainer` command in a kickstart would look like this (*no need to run this command*):
-
-----
-ostreecontainer --url=quay.io/myorg/myimage:mytag
-----
-
-When creating an ISO with an embedded kickstart however, `bootc-image-builder` will automatically inject the correct `ostreecontainer` directive for the image we pass it. The command looks very similar to the one used to create the virtual machine QCOW2 disk in the earlier exercise, with a new output type.
+On the host system (make sure the prompt shows `[lab-user@hypervisor rh-summit-2024-lb1506]$`), and are in the `rh-summit-2024-lb1506` directory
 
 [source,bash]
 ----
-sudo podman run --rm --privileged \
-  --security-opt label=type:unconfined_t \
-  --volume .:/output \
-  --volume ./config-iso.toml:/config.toml \
-  --volume /var/lib/containers/storage:/var/lib/containers/storage \
-  registry.redhat.io/rhel9/bootc-image-builder:latest \
-  --type iso \
-  summit.registry/lb1506:bootc
+cd ~/rh-summit-2024-lb1506
 ----
 
+[#secrets]
+== Using podman secrets at build time
 
-[#run]
-== Starting the installation with Anaconda in a virtual machine
+We will use an addtional feature of `podman` to get the credentials we want to embed passed to the image safely.
 
-Having created a custom installation ISO, we can boot a virtual machine and automatically install our image. Creating
-a virtual machine from scratch is out of scope for this workshop, so we have provided a make command. We are once again using 
-`virt-install` to create a local VM, the main difference is that here we are using the `--location` option to pass the local 
-path of the ISO file to the install process. This emulates inserting a phyiscal disk into a bare metal system.
+You can now edit the `Containerfile` to match the following:
 
+[source,dockerfile]
 ----
-make vm-iso
+FROM registry.redhat.io/rhel9/rhel-bootc:9.4
+
+COPY certs/004-summit.conf /etc/containers/registries.conf.d/004-summit.conf
+
+COPY templates/30-auth-system.conf /etc/ssh/sshd_config.d/30-auth-system.conf # <1>
+RUN mkdir -p /usr/ssh # <2>
+RUN --mount=type=secret,id=SSHPUBKEY cat /run/secrets/SSHPUBKEY > /usr/ssh/root.keys && chmod 0600 /usr/ssh/root.keys # <3>
+
+ADD etc/ /etc
+
+RUN dnf install -y httpd
+
+RUN <<EOF
+    mv /var/www /usr/share/www
+    sed -i 's-/var/www-/usr/share/www-' /etc/httpd/conf/httpd.conf
+EOF
+
+RUN echo "Hello Red Hat Summit Connect 2024!!" > /usr/share/www/html/index.html
+
+RUN systemctl enable httpd.service
+----
+<1> `COPY templates...` -> adds a drop in for sshd to look for public keys in users global `.keys` file, note this is in `/usr` and tied to the image
+<2> `RUN mkdir -p /usr/ssh` -> create the new keys directory in `/usr`
+<3> `RUN --mount=type=secret,id=SSHPUBKEY cat /run/secrets/SSHPUBKEY .. ` -> mounts the secret passed via build to a file only available at build time, then copies the contents
+
+You can now build the new container image with the following command, note the `--secret` argument. This is the connection to the `RUN` directive 
+in the Containerfile. At build time, `podman` will take the file passed and create a temporary secret which we can mount only during the build process. 
+The `id` of the secret is the filename mounted under `/run/secrets`, which we then can extract the contents for our ssh key.
+
+We're also going to use a new tag for this image, like we did in the previous `bootc switch` exercise.
+
+[source,bash]
+----
+podman build --secret id=SSHPUBKEY,src=/home/lab-user/.ssh/id_rsa.pub --file Containerfile --tag summit.registry/lb1506:bootc-auth
 ----
 
-The command above will start the installation process and you should see the console of a newly created virtual machine
-booting from the custom iso. Watch for the Anaconda output as it proceeds with the unattended install. 
+And make sure to push it to the registry:
 
-....
-Powering off.
-[   65.973246] reboot: Power down
+[source,bash]
+----
+podman push summit.registry/lb1506:bootc-auth
+----
 
-Domain creation completed.
-You can restart your domain by running:
-  virsh --connect qemu:///system start iso
-virsh --connect "qemu:///system" start "iso"
-Domain 'iso' started
+[#switch-creds]
+== Changing the virtual machine image
 
-....
-
-You can now see if the virtual machine is running:
+The virtual machine you have been working with during this workshop should still be running. You can check this with
 
 [source,bash]
 ----
 virsh --connect qemu:///system list
 ----
-....
- Id   Name   State
-----------------------
- 1    qcow   running
- 4    iso    running
-....
 
-[#test]
-== Test and login to the virtual machine
+And the output should contain a virtual machine called `qcow`.
 
-Like with the previous virtual machine created, you can directly see if the http application is already running on the host:
+Now you can ssh into the virtual machine
 
 [source,bash]
 ----
-curl http://iso-vm
+ssh lab-user@qcow-vm
 ----
 
-The output should be "Hello Red Hat Summit Connect 2024!!"
-
-You should also be able to login to the virtual machine:
-
-----
-ssh lab-user@iso-vm
-----
-
-If the ssh key is not automatically picked up, use the password `lb1506`.
-
-You can now check the status of `bootc`:
-
-----
-sudo bootc status
-----
-
-The output should be similar to this:
-
-[source,yaml]
-----
-apiVersion: org.containers.bootc/v1alpha1
-kind: BootcHost
-metadata:
-  name: host
-spec:
-  image:
-    image: /run/install/repo/container
-    transport: oci
-  bootOrder: default
-status:
-  staged: null
-  booted:
-    image:
-      image:
-        image: /run/install/repo/container
-        transport: oci
-      version: 9.20240501.0
-      timestamp: null
-      imageDigest: sha256:0a3daed6e31c2f2917e17ea994059e1aaee0481fe16836c118c5e1d10a87365c
-    cachedUpdate: null
-    incompatible: false
-    pinned: false
-    ostree:
-      checksum: 42f36e87a9436d505b3993822b92dbf7961ad3f1a8fddf67b91746df365784f0
-      deploySerial: 0
-  rollback: null
-  rollbackQueued: false
-  type: bootcHost
-----
-
-[#switch]
-== Switching to a different transport method
-
-One thing that immediately is different in the `bootc status` output is that the deployed image image is a local path, not the 
-container naming convention we've been using:
-
-[source,yaml]
-----
-spec:
-  image:
-    image: /run/install/repo/container
-    transport: oci
-  bootOrder: default
-----
-
-The `transport` line refers to the OCI definition of images which includes how they are pulled. The `oci` transport means 
-this is a single image located at a specific local path. This is useful for installing the way we did, but less so for updates. 
-
-So far in this lab, we have been using the `registry` transport, which requires network access. If we wanted to manage updates in an offline manner, 
-say for disconnected environments or those with intermittent connectivity, we can use `containers-storage` which refers to 
-the locally configured shared locations. A full discussion of transports and their associated uses and configuration is outside 
-the scope of this lab.
-
-To keep with the theme of offline usage, let's simulate updating from the local storage. We can use `skopeo` to copy images from one location to another. 
-In the embedded ISO script, it's used to copy from the registry to be included in the final image. Here, we can use it to copy from 
-the registry to the host. We need to be sure to use `sudo` to copy into the system storage location and not the user's.
+We can change to our new image with the embedded `root` credentials
 
 [source,bash]
 ----
-sudo skopeo copy --tls-verify=false docker://summit.registry/lb1506:bootc  containers-storage:summit.registry/lb1506:bootc 
+sudo bootc switch summit.registry/lb1506:bootc-auth
 ----
 
-Switch our installation to use the new container image, using the `--transport` flag to let bootc know we want to use local 
-container storage for this operation.
+The output should look something like this:
 
-[source,bash]
 ----
-sudo bootc switch --transport containers-storage summit.registry/lb1506:bootc
+layers already present: 68; layers needed: 7 (126.7 MB)
+ 452 B [████████████████████] (0s) Fetched layer sha256:2691e6642975            
+Pruned images: 0 (layers: 0, objsize: 58.9 MB)
+Queued for next boot: summit.registry/lb1506:bootc-auth
+  Version: 9.20240721.0
+  Digest: sha256:2afd495b9dd3e72aa4926deb1e738af54e0b1bb935803bc6c107bdd919347167
 ----
-
-....
-Loading usr/lib/ostree/prepare-root.conf
-Queued for next boot: ostree-unverified-image:containers-storage:summit.registry/lb1506:bootc
-  Version: 9.20240501.0
-  Digest: sha256:0a3daed6e31c2f2917e17ea994059e1aaee0481fe16836c118c5e1d10a87365c
-....
-
-At this point, the "new" installation has been prepared and will be started at next boot of the virtual machine.
-
-The last step for the change to take is to reboot the virtual machine. Before doing it, please make sure you are logged in to the
-virtual machine and not the hypervisor (the prompt should look like `[lab-user@lb1506-vm ~]$`):
+As usual, after the command is done you need to reboot the virtual machine
+for the changes to take effect. Before doing that, please make sure you are logged in to the
+virtual machine and not the hypervisor (the prompt should look like `[lab-user@qcow-vm ~]#`):
 
 [source,bash]
 ----
 sudo systemctl reboot
 ----
 
-In a short time after that command, you should be able to ssh back to the virtual machine:
+[#user-test]
+== Testing the changes
+
+You can now login to the virtual machine with the newly added root credentials:
 
 [source,bash]
 ----
-ssh lab-user@iso-vm
+ssh root@qcow-vm
 ----
 
-And check the bootc status:
+And check once again the status of bootc (no need to use `sudo`, you are root):
 
 [source,bash]
 ----
-sudo bootc status
+bootc status
 ----
+
+The output should look like this:
 
 [source,yaml]
 ----
@@ -261,59 +144,51 @@ metadata:
   name: host
 spec:
   image:
-    image: summit.registry/lb1506:bootc
-    transport: containers-storage
+    image: summit.registry/lb1506:bootc-auth
+    transport: registry
   bootOrder: default
 status:
   staged: null
   booted:
     image:
       image:
-        image: summit.registry/lb1506:bootc
-        transport: containers-storage
-      version: 9.20240501.0
+        image: summit.registry/lb1506:bootc-auth
+        transport: registry
+      version: 9.20240721.0
       timestamp: null
-      imageDigest: sha256:0a3daed6e31c2f2917e17ea994059e1aaee0481fe16836c118c5e1d10a87365c
+      imageDigest: sha256:2afd495b9dd3e72aa4926deb1e738af54e0b1bb935803bc6c107bdd919347167
     cachedUpdate: null
     incompatible: false
     pinned: false
     ostree:
-      checksum: 6e468a048b5c86ed8c481040b125b442b9222c914fc12799123717eb94fc43b6
+      checksum: 6307d9fdc8be3f0c202ce49e311b1d046d6d606dea7bcff51ad5d8910f7887b3
       deploySerial: 0
   rollback:
     image:
       image:
-        image: /run/install/repo/container
-        transport: oci
-      version: 9.20240501.0
+        image: summit.registry/lb1506:bootc-wp
+        transport: registry
+      version: 9.20240721.0
       timestamp: null
-      imageDigest: sha256:0a3daed6e31c2f2917e17ea994059e1aaee0481fe16836c118c5e1d10a87365c
+      imageDigest: sha256:af3c6bd4ae7beb9bb10f9846c7bc9d9ba1ede259b4b45e581ddcd97ab2df4380
     cachedUpdate: null
     incompatible: false
     pinned: false
     ostree:
-      checksum: 42f36e87a9436d505b3993822b92dbf7961ad3f1a8fddf67b91746df365784f0
+      checksum: 543f6c9a5b8e2f354db71adda5db7ca74b53bcb9fdf8c8fcd391e7c66c77062a
       deploySerial: 0
   rollbackQueued: false
   type: bootcHost
 ----
 
-In the status you can see `bootc` is now tracking local container storage for updates. Further updates would then be provided on media 
-presented to the host, like a USB drive or DVD. You could use skopeo sync a registry repository to media as well as copy it 
-from the media to the local storage on the host. These images are visible to podman as well. 
+Feel free to explore the virtual machine before moving on to the next section, remembering you are now `root`.
+
+Since we've moved away from the WordPress image back to a standard httpd service, you can look for the original 
+index file on disk or via `curl`.
+
+Before proceeding, make sure you have logged out of the virtual machine:
 
 [source,bash]
 ----
-sudo podman images
+logout
 ----
-
-There are a range of possibilities for edge devices, disconnected networks, and any other arenas where direct connectivity to a 
-registry over a network isn't possible or desired. 
-
-[#complete]
-== Workshop complete!
-You've now completed all of the exercises in today's workshop.
-
-Image mode for RHEL provides a new way to think about risks involved with updating hosts, creates native rollback functionality, 
-and can quickly and easily change the role of a particular host. We hope you've had a few ideas of how the techniques and topics 
-in this workshop could apply to the environments you manage.

--- a/content/modules/ROOT/pages/module-10.adoc
+++ b/content/modules/ROOT/pages/module-10.adoc
@@ -1,0 +1,319 @@
+= Creating an install iso with Anaconda
+
+In this section you will learn the basics of deploying a bootc image using Anaconda and an
+all in one `iso` image.
+
+Anaconda is the official Red Hat Enterprise Linux installer and it uses Kickstart as it's scripting language.
+Recently, Kickstart received a new command called `ostreecontainer`.
+
+[#build]
+== Building an installation ISO with the bootc image
+
+Anaconda is typically used via the boot iso shipped by Red Hat. There are several ways to get a host to boot from this ISO 
+image including PXE or HTTP Boot over the network, as an image via IMPI, or a physical disk inserted into a drive. The kickstart 
+file for an install can also be provided in several ways, including as part of the iso or over a network. For this section of the lab, 
+we'll focus on creating a boot ISO that includes the kickstart, mainly for local logistics reasons. The configuration of 
+Anaconda via kickstart will be the same, regardless of how they are presented to the host being installed.
+
+To create the ISO with an embedded kickstart, we will use `bootc-image-builder`.
+
+Make sure you have the bootc image to be installed pushed to the local registry:
+
+----
+podman push summit.registry/lb1506:bootc
+----
+
+[#kickstart]
+== Creating the kickstart file
+
+The Kickstart added to the iso via a customization block of the `bootc-image-builder` config file. Add the following to `config-iso.toml` and save the file.
+----
+[customizations.installer.kickstart]
+contents = """
+# Basic setup
+text
+
+network --bootproto=dhcp --device=link --activate 
+
+# Basic partitioning
+clearpart --all --initlabel --disklabel=gpt
+reqpart --add-boot
+part / --grow --fstype xfs
+
+# No ostreecontainer command needed, instead we lay down the container contents with BIB in the ISO
+
+firewall --disabled
+services --enabled=sshd
+
+user --name=core --groups=wheel --iscrypted --password=$PASSHASH
+sshkey --username=core "$SSHKEY"
+
+# Only inject a SSH key for root
+rootpw --iscrypted locked
+
+reboot
+----
+
+All of  the kickstart is standard fare. Anaconda will create the partitions and filesystems on disk, enable services, and create users just like it would in any other install. You even have access to the `%pre` and `%post` blocks too, the only missing section from any kickstart you have today is the `%packages` list. 
+
+The new `ostreecontainer` command replaces the standard %packages block of the kickstart file that defines what RPMs would be installed by Anaconda. This replaces that set of RPM transactions with the `bootc` image to be unpacked and installed to disk.  
+
+  * `--url=/run/install/repo/container` -> path to the local container in the iso but it can also directly take a publicly available registry
+  * `--transport=oci` -> the format in which the container is available, in this case `oci`
+
+If you wanted to deploy directly from a container registry, the `ostreecontainer` command in a kickstart would look like this (*no need to run this command*):
+
+----
+ostreecontainer --url=quay.io/myorg/myimage:mytag
+----
+
+When creating an ISO with an embedded kickstart however, `bootc-image-builder` will automatically inject the correct `ostreecontainer` directive for the image we pass it. The command looks very similar to the one used to create the virtual machine QCOW2 disk in the earlier exercise, with a new output type.
+
+[source,bash]
+----
+sudo podman run --rm --privileged \
+  --security-opt label=type:unconfined_t \
+  --volume .:/output \
+  --volume ./config-iso.toml:/config.toml \
+  --volume /var/lib/containers/storage:/var/lib/containers/storage \
+  registry.redhat.io/rhel9/bootc-image-builder:latest \
+  --type iso \
+  summit.registry/lb1506:bootc
+----
+
+
+[#run]
+== Starting the installation with Anaconda in a virtual machine
+
+Having created a custom installation ISO, we can boot a virtual machine and automatically install our image. Creating
+a virtual machine from scratch is out of scope for this workshop, so we have provided a make command. We are once again using 
+`virt-install` to create a local VM, the main difference is that here we are using the `--location` option to pass the local 
+path of the ISO file to the install process. This emulates inserting a phyiscal disk into a bare metal system.
+
+----
+make vm-iso
+----
+
+The command above will start the installation process and you should see the console of a newly created virtual machine
+booting from the custom iso. Watch for the Anaconda output as it proceeds with the unattended install. 
+
+....
+Powering off.
+[   65.973246] reboot: Power down
+
+Domain creation completed.
+You can restart your domain by running:
+  virsh --connect qemu:///system start iso
+virsh --connect "qemu:///system" start "iso"
+Domain 'iso' started
+
+....
+
+You can now see if the virtual machine is running:
+
+[source,bash]
+----
+virsh --connect qemu:///system list
+----
+....
+ Id   Name   State
+----------------------
+ 1    qcow   running
+ 4    iso    running
+....
+
+[#test]
+== Test and login to the virtual machine
+
+Like with the previous virtual machine created, you can directly see if the http application is already running on the host:
+
+[source,bash]
+----
+curl http://iso-vm
+----
+
+The output should be "Hello Red Hat Summit Connect 2024!!"
+
+You should also be able to login to the virtual machine:
+
+----
+ssh lab-user@iso-vm
+----
+
+If the ssh key is not automatically picked up, use the password `lb1506`.
+
+You can now check the status of `bootc`:
+
+----
+sudo bootc status
+----
+
+The output should be similar to this:
+
+[source,yaml]
+----
+apiVersion: org.containers.bootc/v1alpha1
+kind: BootcHost
+metadata:
+  name: host
+spec:
+  image:
+    image: /run/install/repo/container
+    transport: oci
+  bootOrder: default
+status:
+  staged: null
+  booted:
+    image:
+      image:
+        image: /run/install/repo/container
+        transport: oci
+      version: 9.20240501.0
+      timestamp: null
+      imageDigest: sha256:0a3daed6e31c2f2917e17ea994059e1aaee0481fe16836c118c5e1d10a87365c
+    cachedUpdate: null
+    incompatible: false
+    pinned: false
+    ostree:
+      checksum: 42f36e87a9436d505b3993822b92dbf7961ad3f1a8fddf67b91746df365784f0
+      deploySerial: 0
+  rollback: null
+  rollbackQueued: false
+  type: bootcHost
+----
+
+[#switch]
+== Switching to a different transport method
+
+One thing that immediately is different in the `bootc status` output is that the deployed image image is a local path, not the 
+container naming convention we've been using:
+
+[source,yaml]
+----
+spec:
+  image:
+    image: /run/install/repo/container
+    transport: oci
+  bootOrder: default
+----
+
+The `transport` line refers to the OCI definition of images which includes how they are pulled. The `oci` transport means 
+this is a single image located at a specific local path. This is useful for installing the way we did, but less so for updates. 
+
+So far in this lab, we have been using the `registry` transport, which requires network access. If we wanted to manage updates in an offline manner, 
+say for disconnected environments or those with intermittent connectivity, we can use `containers-storage` which refers to 
+the locally configured shared locations. A full discussion of transports and their associated uses and configuration is outside 
+the scope of this lab.
+
+To keep with the theme of offline usage, let's simulate updating from the local storage. We can use `skopeo` to copy images from one location to another. 
+In the embedded ISO script, it's used to copy from the registry to be included in the final image. Here, we can use it to copy from 
+the registry to the host. We need to be sure to use `sudo` to copy into the system storage location and not the user's.
+
+[source,bash]
+----
+sudo skopeo copy --tls-verify=false docker://summit.registry/lb1506:bootc  containers-storage:summit.registry/lb1506:bootc 
+----
+
+Switch our installation to use the new container image, using the `--transport` flag to let bootc know we want to use local 
+container storage for this operation.
+
+[source,bash]
+----
+sudo bootc switch --transport containers-storage summit.registry/lb1506:bootc
+----
+
+....
+Loading usr/lib/ostree/prepare-root.conf
+Queued for next boot: ostree-unverified-image:containers-storage:summit.registry/lb1506:bootc
+  Version: 9.20240501.0
+  Digest: sha256:0a3daed6e31c2f2917e17ea994059e1aaee0481fe16836c118c5e1d10a87365c
+....
+
+At this point, the "new" installation has been prepared and will be started at next boot of the virtual machine.
+
+The last step for the change to take is to reboot the virtual machine. Before doing it, please make sure you are logged in to the
+virtual machine and not the hypervisor (the prompt should look like `[lab-user@lb1506-vm ~]$`):
+
+[source,bash]
+----
+sudo systemctl reboot
+----
+
+In a short time after that command, you should be able to ssh back to the virtual machine:
+
+[source,bash]
+----
+ssh lab-user@iso-vm
+----
+
+And check the bootc status:
+
+[source,bash]
+----
+sudo bootc status
+----
+
+[source,yaml]
+----
+apiVersion: org.containers.bootc/v1alpha1
+kind: BootcHost
+metadata:
+  name: host
+spec:
+  image:
+    image: summit.registry/lb1506:bootc
+    transport: containers-storage
+  bootOrder: default
+status:
+  staged: null
+  booted:
+    image:
+      image:
+        image: summit.registry/lb1506:bootc
+        transport: containers-storage
+      version: 9.20240501.0
+      timestamp: null
+      imageDigest: sha256:0a3daed6e31c2f2917e17ea994059e1aaee0481fe16836c118c5e1d10a87365c
+    cachedUpdate: null
+    incompatible: false
+    pinned: false
+    ostree:
+      checksum: 6e468a048b5c86ed8c481040b125b442b9222c914fc12799123717eb94fc43b6
+      deploySerial: 0
+  rollback:
+    image:
+      image:
+        image: /run/install/repo/container
+        transport: oci
+      version: 9.20240501.0
+      timestamp: null
+      imageDigest: sha256:0a3daed6e31c2f2917e17ea994059e1aaee0481fe16836c118c5e1d10a87365c
+    cachedUpdate: null
+    incompatible: false
+    pinned: false
+    ostree:
+      checksum: 42f36e87a9436d505b3993822b92dbf7961ad3f1a8fddf67b91746df365784f0
+      deploySerial: 0
+  rollbackQueued: false
+  type: bootcHost
+----
+
+In the status you can see `bootc` is now tracking local container storage for updates. Further updates would then be provided on media 
+presented to the host, like a USB drive or DVD. You could use skopeo sync a registry repository to media as well as copy it 
+from the media to the local storage on the host. These images are visible to podman as well. 
+
+[source,bash]
+----
+sudo podman images
+----
+
+There are a range of possibilities for edge devices, disconnected networks, and any other arenas where direct connectivity to a 
+registry over a network isn't possible or desired. 
+
+[#complete]
+== Workshop complete!
+You've now completed all of the exercises in today's workshop.
+
+Image mode for RHEL provides a new way to think about risks involved with updating hosts, creates native rollback functionality, 
+and can quickly and easily change the role of a particular host. We hope you've had a few ideas of how the techniques and topics 
+in this workshop could apply to the environments you manage.


### PR DESCRIPTION
Inserts a new module to talk about how to update the base image after the module on adding software. Expands on container naming, introduces tagging.

Pulls local testing forward to this module, would remove that current module entirely (now module 8) 

Navigation updated to shuffle existing modules, still needs some removal and reordering after this PR.

Fixes #13 